### PR TITLE
Update Rolling CI to Noble and add Jazzy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ros: humble
+          - ros_distro: humble
             ubuntu: jammy
-          - ros: iron
+          - ros_distro: iron
             ubuntu: jammy
-          - ros: jazzy
+          - ros_distro: jazzy
             ubuntu: noble
-          - ros: rolling
+          - ros_distro: rolling
             ubuntu: noble
     runs-on: ubuntu-latest
     container:
@@ -30,7 +30,7 @@ jobs:
       uses: ros-tooling/action-ros-ci@v0.3
       with:
         import-token: ${{ secrets.GITHUB_TOKEN }}
-        target-ros2-distro: ${{ matrix.ros }}
+        target-ros2-distro: ${{ matrix.ros_distro }}
         colcon-defaults: |
           {
             "build": {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,11 @@ on:
 
 jobs:
   build_and_test:
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-${{ matrix.ubuntu }}-latest
+    env:
+      ROS_DISTRO: ${{ matrix.ros_distro }}
     strategy:
       fail-fast: false
       matrix:
@@ -19,11 +24,6 @@ jobs:
             ubuntu: noble
           - ros_distro: rolling
             ubuntu: noble
-    runs-on: ubuntu-latest
-    container:
-      image: rostooling/setup-ros-docker:ubuntu-${{ matrix.ubuntu }}-latest
-    env:
-      ROS_DISTRO: ${{ matrix.ros_distro }}
     steps:
     - name: Build and run tests
       id: action-ros-ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,22 +7,30 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
-    env:
-      ROS_DISTRO: ${{ matrix.ros_distro }}
-    container:
-      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     strategy:
       fail-fast: false
       matrix:
-          ros_distro: [humble, iron, rolling]
+        include:
+          - ros: humble
+            ubuntu: jammy
+          - ros: iron
+            ubuntu: jammy
+          - ros: jazzy
+            ubuntu: noble
+          - ros: rolling
+            ubuntu: noble
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-${{ matrix.ubuntu }}-latest
+    env:
+      ROS_DISTRO: ${{ matrix.ros_distro }}
     steps:
     - name: Build and run tests
       id: action-ros-ci
       uses: ros-tooling/action-ros-ci@v0.3
       with:
         import-token: ${{ secrets.GITHUB_TOKEN }}
-        target-ros2-distro: ${{ matrix.ros_distro }}
+        target-ros2-distro: ${{ matrix.ros }}
         colcon-defaults: |
           {
             "build": {


### PR DESCRIPTION
ROS 2 Jazzy Jalisco targets Ubuntu Noble Numbat, and so Rolling has upgraded. A Jazzy release candidate build is available now too so I turn on CI for that as well.

Should unblock #7