### PR TITLE
Hardware decoding of frames

### DIFF
--- a/broll/CMakeLists.txt
+++ b/broll/CMakeLists.txt
@@ -78,6 +78,9 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+ament_export_dependencies(
+  sensor_msgs
+)
 ament_export_include_directories(
   "include/${PROJECT_NAME}"
 )

--- a/broll/include/broll/frame_decoder.hpp
+++ b/broll/include/broll/frame_decoder.hpp
@@ -97,8 +97,13 @@ protected:
   AVFrame * convertedFrame_ = nullptr;
 
   // Hardware decoding extras
-  AVPixelFormat hwPixFmt_ = AV_PIX_FMT_NONE;  // Pixel format on the hardware memory side
-  AVPixelFormat hwSoftwarePixFmt_ = AV_PIX_FMT_NONE;  // Software-side pixel format from hardware
+  // Pixel format reported for an on-hardware DMA frame, such as "cuda", which isn't
+  // a real pixel format but how the frame reports that it isn't in CPU memory.
+  AVPixelFormat hwPixFmt_ = AV_PIX_FMT_NONE;
+  // Pixel format to convert to when transferring the frame from hardware into CPU memory.
+  // Hardware devices offer several options, but not all that we might want so this
+  // is the pre-conversion format before sws.
+  AVPixelFormat hwSoftwarePixFmt_ = AV_PIX_FMT_NONE;
   AVBufferRef * hwDeviceCtx_ = nullptr;
   AVFrame * hwFrame_ = nullptr;
 

--- a/broll/include/broll/frame_decoder.hpp
+++ b/broll/include/broll/frame_decoder.hpp
@@ -43,7 +43,8 @@ public:
     AVCodecID codec_id,
     AVPixelFormat target_fmt = AV_PIX_FMT_NONE,
     double scale = 1.0f,
-    bool dbg_print = false);
+    bool dbg_print = false,
+    bool use_cuda = false);
   virtual ~FrameDecoder();
 
   /// @brief Decode a compressed image packet into an image message
@@ -85,6 +86,7 @@ protected:
   AVPixelFormat targetPixFmt_ = AV_PIX_FMT_NONE;
   SwsContext * swsCtx_ = nullptr;
   AVFrame * decodedFrame_ = nullptr;
+  AVFrame * hardwareFrame_ = nullptr;
   AVFrame * convertedFrame_ = nullptr;
 
   float scale_ = 1.0f;

--- a/broll/include/broll/frame_decoder.hpp
+++ b/broll/include/broll/frame_decoder.hpp
@@ -97,7 +97,8 @@ protected:
   AVFrame * convertedFrame_ = nullptr;
 
   // Hardware decoding extras
-  AVPixelFormat hwPixFmt_ = AV_PIX_FMT_NONE;
+  AVPixelFormat hwPixFmt_ = AV_PIX_FMT_NONE;  // Pixel format on the hardware memory side
+  AVPixelFormat hwSoftwarePixFmt_ = AV_PIX_FMT_NONE;  // Software-side pixel format from hardware
   AVBufferRef * hwDeviceCtx_ = nullptr;
   AVFrame * hwFrame_ = nullptr;
 

--- a/broll/src/frame_decoder.cpp
+++ b/broll/src/frame_decoder.cpp
@@ -44,9 +44,37 @@ static AVFrame * allocPicture(enum AVPixelFormat pix_fmt, int width, int height)
   int ret = av_frame_get_buffer(picture, 0);
   if (ret < 0) {
     fprintf(stderr, "Could not allocate frame data.\n");
-    exit(1);
+    return nullptr;
   }
   return picture;
+}
+
+static int hw_decoder_init(AVBufferRef ** hw_device_ctx, AVCodecContext *ctx, const enum AVHWDeviceType type)
+{
+  int err = av_hwdevice_ctx_create(hw_device_ctx, type, nullptr, nullptr, 0);
+  if (err < 0) {
+    BROLL_LOG_ERROR("Failed to create specified HW device.");
+    return err;
+  }
+  ctx->hw_device_ctx = av_buffer_ref(*hw_device_ctx);
+  return err;
+}
+
+static enum AVPixelFormat hw_pix_fmt;
+static enum AVPixelFormat get_hw_format(
+  AVCodecContext *,
+  const AVPixelFormat * pix_fmts)
+{
+  const enum AVPixelFormat *p;
+
+  for (p = pix_fmts; *p != -1; p++) {
+    if (*p == hw_pix_fmt) {
+      return *p;
+    }
+  }
+
+  fprintf(stderr, "Failed to get HW surface format.\n");
+  return AV_PIX_FMT_NONE;
 }
 
 static const int64_t NS_TO_S = 1000000000;
@@ -60,7 +88,8 @@ FrameDecoder::FrameDecoder(
   AVCodecID codec_id,
   AVPixelFormat target_fmt,
   double scale,
-  bool dbg_print)
+  bool dbg_print,
+  bool use_cuda)
 : targetPixFmt_(target_fmt),
   scale_(scale),
   dbg_print_(dbg_print)
@@ -79,6 +108,28 @@ FrameDecoder::FrameDecoder(
     assert(false);
   }
 
+  AVHWDeviceType hw_device_type = av_hwdevice_find_type_by_name("cuda");
+  if (use_cuda) {
+    if (hw_device_type == AV_HWDEVICE_TYPE_NONE) {
+      BROLL_LOG_ERROR("Device type cuda is not supported");
+      assert(false);
+    }
+    for (size_t i = 0;; i++) {
+      const AVCodecHWConfig * config = avcodec_get_hw_config(codec_, i);
+      if (!config) {
+        BROLL_LOG_ERROR(
+          "Decoder %s does not support device type %s.\n",
+          codec_->name, av_hwdevice_get_type_name(hw_device_type));
+        assert(false);
+      }
+      if (config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX && config->device_type == hw_device_type) {
+        hw_pix_fmt = config->pix_fmt;
+        break;
+      }
+    }
+    BROLL_LOG_INFO("Found HW pixel format %d", hw_pix_fmt);
+  }
+
   codecCtx_ = avcodec_alloc_context3(codec_);
   if (!codecCtx_) {
     BROLL_LOG_ERROR("Failed to alloc context");
@@ -89,6 +140,18 @@ FrameDecoder::FrameDecoder(
 
   if (avcodec_parameters_to_context(codecCtx_, params) < 0) {
     assert(false && "failed to copy codec params to codec context");
+  }
+
+  AVBufferRef * hw_device_ctx = nullptr;
+  if (use_cuda) {
+    codecCtx_->get_format = get_hw_format;
+    if (hw_decoder_init(&hw_device_ctx, codecCtx_, hw_device_type) < 0) {
+      assert(false && "Failed to initialize hardware decoder");
+    } else {
+      BROLL_LOG_INFO("Succeeded to init hardware decoder");
+      hardwareFrame_ = av_frame_alloc();
+      assert(hardwareFrame_ && "failed to alloc softwareFrame");
+    }
   }
 
   if (avcodec_open2(codecCtx_, codec_, nullptr) < 0) {
@@ -122,7 +185,13 @@ bool FrameDecoder::decodeFrame(const AVPacket & packet_in, AVFrame & frame_out)
     BROLL_LOG_ERROR("avcodec_send_packet failed: %s", errStr);
     return false;
   }
-  const int recv_frame_resp = avcodec_receive_frame(codecCtx_, &frame_out);
+
+  int recv_frame_resp;
+  if (hardwareFrame_) {
+    recv_frame_resp = avcodec_receive_frame(codecCtx_, hardwareFrame_);
+  } else {
+    recv_frame_resp = avcodec_receive_frame(codecCtx_, &frame_out);
+  }
   if (recv_frame_resp == AVERROR(EAGAIN)) {
     BROLL_LOG_DEBUG("avcodec_receive_frame returned EAGAIN");
     return false;
@@ -135,6 +204,14 @@ bool FrameDecoder::decodeFrame(const AVPacket & packet_in, AVFrame & frame_out)
   }
   if (recv_frame_resp < 0) {
     return false;
+  }
+
+  if (hardwareFrame_ && hardwareFrame_->format == hw_pix_fmt) {
+    frame_out.format = AV_PIX_FMT_NV12;
+    if (av_hwframe_transfer_data(&frame_out, hardwareFrame_, 0) < 0) {
+      BROLL_LOG_ERROR("Error transferring the data to system memory");
+      return false;
+    }
   }
 
 #if LIBAVCODEC_VERSION_MAJOR >= 60
@@ -231,13 +308,18 @@ bool FrameDecoder::decode(const AVPacket & in, sensor_msgs::msg::Image & out)
     BROLL_LOG_INFO(
       "Frame Decoder initialized: resolution in %d x %d, resolution out %d x %d",
       width, height, scaled_width_, scaled_height_);
-    BROLL_LOG_INFO("\tCodec %s ID %d", codec_->name, codec_->id);
+    BROLL_LOG_INFO("\tCodec %d ('%s')", codec_->id, codec_->name);
+    BROLL_LOG_INFO(
+      "\tCodec pixfmt '%s', decoded pixfmt '%s'",
+      av_get_pix_fmt_name(codecCtx_->pix_fmt),
+      av_get_pix_fmt_name(static_cast<AVPixelFormat>(decodedFrame_->format)));
+    BROLL_LOG_INFO("\tTarget pixfmt '%s'", av_get_pix_fmt_name(targetPixFmt_));
 
     convertedFrame_ = allocPicture(targetPixFmt_, scaled_width_, scaled_height_);
     assert(convertedFrame_ && "failed to alloc convertedFrame");
 
     bool set_extended_color_range = false;
-    AVPixelFormat sws_pix_fmt = codecCtx_->pix_fmt;
+    AVPixelFormat sws_pix_fmt = static_cast<AVPixelFormat>(decodedFrame_->format);
     switch (sws_pix_fmt) {
       case AV_PIX_FMT_YUVJ420P:
         sws_pix_fmt = AV_PIX_FMT_YUV420P;

--- a/broll/src/frame_decoder.cpp
+++ b/broll/src/frame_decoder.cpp
@@ -49,7 +49,10 @@ static AVFrame * allocPicture(enum AVPixelFormat pix_fmt, int width, int height)
   return picture;
 }
 
-static int hw_decoder_init(AVBufferRef ** hw_device_ctx, AVCodecContext *ctx, const enum AVHWDeviceType type)
+static int hw_decoder_init(
+  AVBufferRef ** hw_device_ctx,
+  AVCodecContext * ctx,
+  const AVHWDeviceType type)
 {
   int err = av_hwdevice_ctx_create(hw_device_ctx, type, nullptr, nullptr, 0);
   if (err < 0) {
@@ -60,12 +63,12 @@ static int hw_decoder_init(AVBufferRef ** hw_device_ctx, AVCodecContext *ctx, co
   return err;
 }
 
-static enum AVPixelFormat hw_pix_fmt;
-static enum AVPixelFormat get_hw_format(
+static AVPixelFormat hw_pix_fmt;
+static AVPixelFormat get_hw_format(
   AVCodecContext *,
   const AVPixelFormat * pix_fmts)
 {
-  const enum AVPixelFormat *p;
+  const AVPixelFormat * p;
 
   for (p = pix_fmts; *p != -1; p++) {
     if (*p == hw_pix_fmt) {
@@ -122,7 +125,10 @@ FrameDecoder::FrameDecoder(
           codec_->name, av_hwdevice_get_type_name(hw_device_type));
         assert(false);
       }
-      if (config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX && config->device_type == hw_device_type) {
+      if (
+        config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX &&
+        config->device_type == hw_device_type)
+      {
         hw_pix_fmt = config->pix_fmt;
         break;
       }

--- a/rosbag2_storage_broll/CMakeLists.txt
+++ b/rosbag2_storage_broll/CMakeLists.txt
@@ -78,6 +78,9 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+ament_export_dependencies(
+  rosbag2_transport
+)
 ament_export_libraries(
   bag_utils
 )


### PR DESCRIPTION
Add a flag to enable hardware decoders, specifically CUDA. Improves even single-threaded performance by ~3-3.5x on my machine.  For this specific HEVC 1920*1080 test data, that's ~99fps -> ~350fps, and at the new speed it's I/O bound the CPU is not maxed out when it's doing that.

This leaves room for further upgrades:
* Parallelize feeding frames to GPU and getting them back - right now we're I/O bound, not CPU-bound (depending on the CPU of course) shuttling data to and from GPU
* Perform pixel format conversion and scaling on GPU as well - this remains on the CPU and is now the majority of CPU usage by the decoder when using hardware